### PR TITLE
Fix multi-passenger parser error, support upstart jobs, disable syslogger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,9 +56,9 @@ gem 'newrelic_rpm'
 # Pagination
 gem 'kaminari'
 
-# Logging in production
-gem 'syslogger', '~> 1.6.0'
-gem 'lograge', '~> 0.3.1'
+# syslog logging with lograge
+# gem 'syslogger', '~> 1.6.0'
+# gem 'lograge', '~> 0.3.1'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,10 +139,6 @@ GEM
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    lograge (0.3.5)
-      actionpack (>= 3)
-      activesupport (>= 3)
-      railties (>= 3)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.9)
@@ -296,7 +292,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    syslogger (1.6.1)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
@@ -347,7 +342,6 @@ DEPENDENCIES
   json-schema-rspec
   kaminari
   letter_opener
-  lograge (~> 0.3.1)
   mina
   mina-newrelic
   mina-puma
@@ -369,7 +363,6 @@ DEPENDENCIES
   skylight
   spring
   spring-commands-rspec
-  syslogger (~> 1.6.0)
   timecop
   turbolinks
   typhoeus (~> 0.7)

--- a/app/parsers/checkin_parser.rb
+++ b/app/parsers/checkin_parser.rb
@@ -27,8 +27,8 @@ class CheckinParser
       passengers.first
     else
       passengers.where(
-        first_name: doc['passenger']['secureFlightFirstName'],
-        last_name: doc['passenger']['secureFlightLastName']).first
+        first_name: passenger_checkin_document['passenger']['secureFlightFirstName'],
+        last_name: passenger_checkin_document['passenger']['secureFlightLastName']).first
     end
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
@@ -54,12 +54,12 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  require 'syslogger'
-  config.logger = ActiveSupport::TaggedLogging.new(Syslogger.new("southwest-checkin", Syslog::LOG_PID, Syslog::LOG_LOCAL7))
-  config.lograge.enabled = true
-  config.lograge.formatter = Lograge::Formatters::Json.new
+  # require 'syslogger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslogger.new("southwest-checkin", Syslog::LOG_PID, Syslog::LOG_LOCAL7))
+  # config.lograge.enabled = true
+  # config.lograge.formatter = Lograge::Formatters::Json.new
 
-  Sidekiq::Logging.logger = ActiveSupport::TaggedLogging.new(Syslogger.new("sidekiq", Syslog::LOG_PID, Syslog::LOG_LOCAL7))
+  # Sidekiq::Logging.logger = ActiveSupport::TaggedLogging.new(Syslogger.new("sidekiq", Syslog::LOG_PID, Syslog::LOG_LOCAL7))
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Syslogger has been a larger burden than benefit. This adds a change to support deploying to an environment where puma and sidekiq are run with upstart so that they respawn properly on crashes and start on boot.

Fixes #49.