### PR TITLE
Notify on international flights, use alternative flight number field

### DIFF
--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -39,6 +39,15 @@ $Reservation-bg-color: darken($logo-blue, 10%);
   }
 }
 
+.Reservation-notice {
+  background-color: $yellow;
+  max-width: 300px;
+  margin: 0 auto 20px auto;
+  padding: 20px;
+  border-radius: 10px;
+  font-size: 12px;
+}
+
 .ReservationCard-label,
 .ReservationCard-flight-group-title {
   color: $wild-rice;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -10,6 +10,7 @@ $curious-blue-light: #3498DB;
 $alert-red: #D40D12;
 $success-green: #45BF55;
 $wild-rice: rgb(231, 217, 123);
+$yellow: #ffde00;
 
 
 /* Header

--- a/app/parsers/checkin_parser.rb
+++ b/app/parsers/checkin_parser.rb
@@ -11,7 +11,7 @@ class CheckinParser
     checkin_response.body['passengerCheckInDocuments'].map do |doc|
       first_doc = doc['checkinDocuments'][0]
       {
-        flight_number: first_doc['flightNumber'],
+        flight_number: flight_number(first_doc),
         boarding_group: first_doc['boardingGroup'],
         boarding_position: first_doc['boardingGroupNumber'],
         checkin: checkin_record,
@@ -33,6 +33,12 @@ class CheckinParser
   end
 
   def flight(checkin_document)
-    checkin_record.reservation.flights.where(flight_number: checkin_document['flightNumber']).first
+    checkin_record.reservation.flights.where(flight_number: flight_number(checkin_document)).first
+  end
+
+  private
+
+  def flight_number(checkin_document)
+    checkin_document['flightNumber'] || checkin_document['carrierInfo']['flightNumber']
   end
 end

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -1,4 +1,9 @@
 <div class="Reservation">
+  <% if @reservation.payload['body']['international'] %>
+    <div class="Reservation-notice">
+      International flights require passport information for check in. If passport information is not attached to your Southwest account reservation, a manual check in will be required.
+    </div>
+  <% end %>
   <div class="ReservationCard">
     <div class="ReservationCard-header ReservationCard-indention-top">
       <div class="ReservationCard-passengers">

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -11,7 +11,7 @@ def create_reservation(cassette, user)
       confirmation_number: "ABC123",
       first_name: "Fuu",
       last_name: "Bar"
-    }).first_or_create
+    }).first_or_create!
   end
 end
 
@@ -25,14 +25,14 @@ def checkin_reservation(cassette, reservation)
 end
 
 def checkin_flight(flight)
-    Rails.application.config.active_job.queue_adapter = :inline
-    checkin = Checkin.find_or_initialize_by(flight: flight)
-    checkin.scheduled_at = Time.zone.now
-    checkin.save!
+  Rails.application.config.active_job.queue_adapter = :inline
+  checkin = Checkin.find_or_initialize_by(flight: flight)
+  checkin.scheduled_at = Time.zone.now
+  checkin.save!
 
-    job = CheckinJob.perform_later(flight)
+  job = CheckinJob.perform_later(flight)
 
-    checkin.update({ job_id: job.job_id })
+  checkin.update({ job_id: job.job_id })
 end
 
 namespace :dev do
@@ -41,8 +41,8 @@ namespace :dev do
     require 'vcr'
     require_relative '../../spec/helpers/vcr_helper'
 
-    reservation_cassette = 'viewAirReservation multiple passengers sfo bwi 1 stop'
-    checkin_cassette = 'checkin multiple passengers sfo bwi 1 stop'
+    reservation_cassette = 'record_locator_view_multi_LAX_2016-03-18'
+    checkin_cassette = 'record_locator_checkin_LAX_2016-03-18'
 
     fuu = create_user
     reservation = create_reservation(reservation_cassette, fuu)

--- a/spec/fixtures/airports.yml
+++ b/spec/fixtures/airports.yml
@@ -194,3 +194,33 @@ LAX:
   timezone_offset: "-8.0"
   dst: A
   timezone: America/Los_Angeles
+
+BZE:
+  id: '1919'
+  name: Philip S W Goldson Intl
+  city: Belize City
+  country: Belize
+  iata: BZE
+  icao: MZBZ
+  latitude: '17.539144'
+  longitude: "-88.308203"
+  airport_id: '1957'
+  altitude: '15'
+  timezone_offset: "-6.0"
+  dst: U
+  timezone: America/Belize
+
+HOU:
+  id: '3468'
+  name: William P Hobby
+  city: Houston
+  country: United States
+  iata: HOU
+  icao: KHOU
+  latitude: '29.645419'
+  longitude: "-95.278889"
+  airport_id: '3566'
+  altitude: '46'
+  timezone_offset: "-6.0"
+  dst: A
+  timezone: America/Chicago

--- a/spec/fixtures/vcr_cassettes/international_multi_passenger_2016-07-09.yml
+++ b/spec/fixtures/vcr_cassettes/international_multi_passenger_2016-07-09.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123/boarding-passes
+    body:
+      encoding: UTF-8
+      string: '{"names":[{"firstName":"Fuu","lastName":"Bar"}]}'
+    headers:
+      User-Agent:
+      - Southwest/3.3.7 (iPhone; iOS 9.3; Scale/2.00)
+      Content-Type:
+      - application/vnd.swacorp.com.mobile.boarding-passes-v1.0+json
+      X-Api-Key:
+      - l7xx8d8bfce4ee874269bedc02832674129b
+      Accept-Language:
+      - en-US;q=1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Correlationid:
+      - YnbgBUQWTnSCD6T8hIL30w-API
+      Content-Type:
+      - application/vnd.swacorp.com.mobile.boarding-passes-v1.0+json
+      Content-Length:
+      - '3675'
+      Date:
+      - Sat, 09 Jul 2016 21:49:31 GMT
+      Access-Control-Allow-Origin:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"maxFailedCheckInAttemptsReached":false,"passengerCheckInDocuments":[{"passenger":{"secureFlightFirstName":"FUU
+        QIX","secureFlightLastName":"BAR","secureFlightMiddleName":null,"secureFlightSuffix":null,"loyaltyAccountNumber":"20XXXXXXXXX","tier":"NON_ELITE","birthDate":"1969-12-31","specialConditions":[],"redressNumber":"","gender":"MALE","passengerTypePrefix":"","travelerId":"204XXXXXXXXXXXXX","passengerType":"ADULT","recordLocator":"ABC123","hasExtraSeat":false,"hasLapChild":false},"checkinDocuments":[{"boardingGroupNumber":"31","boardingGroup":"B","documentType":"cleared","departureDateTime":"2016-07-10T12:00:00.000-05:00","arrivalDateTime":"2016-07-10T13:05:00.000-06:00","origin":"DAL","destination":"HOU","secureFlightBarCode":"","fareProductType":"companion","gate":"8","flightNumber":null,"hasPreCheck":false,"originName":"Dallas
+        (Love Field)","destinationName":"Houston (Hobby)","carrierInfo":{"carrierCode":"WN","flightNumber":"1234"},"drinkCouponBarCode":"","issued":true,"nonRevenue":false,"reprint":true,"seat":null,"durationMinutes":125,"documentReason":"","earlyBirdPurchased":false,"originationTerminal":"1","aircraftEquipmentType":"735","wifiOnBoard":false},{"boardingGroupNumber":"32","boardingGroup":"B","documentType":"cleared","departureDateTime":"2016-07-10T14:20:00.000-05:00","arrivalDateTime":"2016-07-10T15:45:00.000-06:00","origin":"HOU","destination":"BZE","secureFlightBarCode":"","fareProductType":"companion","gate":"2","flightNumber":null,"hasPreCheck":false,"originName":"Houston
+        (Hobby)","destinationName":"Belize City","carrierInfo":{"carrierCode":"WN","flightNumber":"4567"},"drinkCouponBarCode":"","issued":true,"nonRevenue":false,"reprint":true,"seat":null,"durationMinutes":145,"documentReason":"","earlyBirdPurchased":false,"aircraftEquipmentType":"73W","wifiOnBoard":true}],"mobileBoardingPassEligible":false},{"passenger":{"secureFlightFirstName":"JOHN
+        APPLE","secureFlightLastName":"SMITH","secureFlightMiddleName":null,"secureFlightSuffix":null,"loyaltyAccountNumber":"20XXXXXXXXY","tier":"NON_ELITE","birthDate":"1969-12-13","specialConditions":[],"redressNumber":"","gender":"MALE","passengerTypePrefix":"","travelerId":"20XXXXXXXXXXXXXX","passengerType":"ADULT","recordLocator":"ABC123","hasExtraSeat":false,"hasLapChild":false},"checkinDocuments":[{"boardingGroupNumber":"33","boardingGroup":"B","documentType":"cleared","departureDateTime":"2016-07-10T12:00:00.000-05:00","arrivalDateTime":"2016-07-10T13:05:00.000-06:00","origin":"DAL","destination":"HOU","secureFlightBarCode":"","fareProductType":"wannaGetAway","gate":"8","flightNumber":null,"hasPreCheck":false,"originName":"Dallas
+        (Love Field)","destinationName":"Houston (Hobby)","carrierInfo":{"carrierCode":"WN","flightNumber":"1234"},"drinkCouponBarCode":"","issued":true,"nonRevenue":false,"reprint":true,"seat":null,"durationMinutes":125,"documentReason":"","earlyBirdPurchased":false,"originationTerminal":"1","aircraftEquipmentType":"735","wifiOnBoard":false},{"boardingGroupNumber":"35","boardingGroup":"B","documentType":"cleared","departureDateTime":"2016-07-10T14:20:00.000-05:00","arrivalDateTime":"2016-07-10T15:45:00.000-06:00","origin":"HOU","destination":"BZE","secureFlightBarCode":"","fareProductType":"wannaGetAway","gate":"2","flightNumber":null,"hasPreCheck":false,"originName":"Houston
+        (Hobby)","destinationName":"Belize City","carrierInfo":{"carrierCode":"WN","flightNumber":"4567"},"drinkCouponBarCode":"","issued":true,"nonRevenue":false,"reprint":true,"seat":null,"durationMinutes":145,"documentReason":"","earlyBirdPurchased":false,"aircraftEquipmentType":"73W","wifiOnBoard":true}],"mobileBoardingPassEligible":false}]}'
+    http_version: 
+  recorded_at: Sat, 09 Jul 2016 21:49:32 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/international_single_passenger_2016-07-09.yml
+++ b/spec/fixtures/vcr_cassettes/international_single_passenger_2016-07-09.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123/boarding-passes
+    body:
+      encoding: UTF-8
+      string: '{"names":[{"firstName":"Fuu","lastName":"Bar"}]}'
+    headers:
+      User-Agent:
+      - Southwest/3.3.7 (iPhone; iOS 9.3; Scale/2.00)
+      Content-Type:
+      - application/vnd.swacorp.com.mobile.boarding-passes-v1.0+json
+      X-Api-Key:
+      - l7xx8d8bfce4ee874269bedc02832674129b
+      Accept-Language:
+      - en-US;q=1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Correlationid:
+      - _3jBjejxQcCGMtinW9dpSQ-API
+      Content-Type:
+      - application/vnd.swacorp.com.mobile.boarding-passes-v1.0+json
+      Content-Length:
+      - '1853'
+      Date:
+      - Sat, 09 Jul 2016 21:49:28 GMT
+      Access-Control-Allow-Origin:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"maxFailedCheckInAttemptsReached":false,"passengerCheckInDocuments":[{"passenger":{"secureFlightFirstName":"FUU","secureFlightLastName":"BAR","secureFlightMiddleName":null,"secureFlightSuffix":null,"loyaltyAccountNumber":null,"tier":null,"birthDate":"1969-12-31","specialConditions":[],"redressNumber":"","gender":"FEMALE","passengerTypePrefix":"","travelerId":"200XXXXXXXXXXXXX","passengerType":"ADULT","recordLocator":"ABC123","hasExtraSeat":false,"hasLapChild":false},"checkinDocuments":[{"boardingGroupNumber":"39","boardingGroup":"B","documentType":"cleared","departureDateTime":"2016-07-10T09:50:00.000-05:00","arrivalDateTime":"2016-07-10T13:25:00.000-06:00","origin":"MCI","destination":"HOU","secureFlightBarCode":"","fareProductType":"wannaGetAway","gate":"B43","flightNumber":null,"hasPreCheck":false,"originName":"Kansas
+        City","destinationName":"Houston (Hobby)","carrierInfo":{"carrierCode":"WN","flightNumber":"1234"},"drinkCouponBarCode":"","issued":true,"nonRevenue":false,"reprint":true,"seat":null,"durationMinutes":275,"documentReason":"","earlyBirdPurchased":false,"originationTerminal":"B","aircraftEquipmentType":"73W","wifiOnBoard":true},{"boardingGroupNumber":"31","boardingGroup":"B","documentType":"cleared","departureDateTime":"2016-07-10T14:20:00.000-05:00","arrivalDateTime":"2016-07-10T15:45:00.000-06:00","origin":"HOU","destination":"BZE","secureFlightBarCode":"","fareProductType":"wannaGetAway","gate":"2","flightNumber":null,"hasPreCheck":false,"originName":"Houston
+        (Hobby)","destinationName":"Belize City","carrierInfo":{"carrierCode":"WN","flightNumber":"4567"},"drinkCouponBarCode":"","issued":true,"nonRevenue":false,"reprint":true,"seat":null,"durationMinutes":145,"documentReason":"","earlyBirdPurchased":false,"aircraftEquipmentType":"73W","wifiOnBoard":true}],"mobileBoardingPassEligible":false}]}'
+    http_version: 
+  recorded_at: Sat, 09 Jul 2016 21:49:28 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/viewAirReservation_multiple_passengers_sfo_bwi_1_stop.yml
+++ b/spec/fixtures/vcr_cassettes/viewAirReservation_multiple_passengers_sfo_bwi_1_stop.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-extensions.southwest.com/v1/mobile/reservations/record-locator/ABC123?action=VIEW&first-name=Fuu&last-name=Bar
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Southwest/3.3.7 (iPhone; iOS 9.3; Scale/2.00)
+      Content-Type:
+      - application/vnd.swacorp.com.mobile.reservations-v1.0+json
+      X-Api-Key:
+      - l7xx8d8bfce4ee874269bedc02832674129b
+      Accept-Language:
+      - en-US;q=1
+      X-Newrelic-Id:
+      - VQQGVl9VABABXFlXAggCXw==
+      X-Newrelic-Transaction:
+      - P1hCDQpPXlJcFwROWURbCkhfQ18OOw==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Correlationid:
+      - AfxYUfq-SkCMgYXK4vqSGw-API
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '175'
+      Date:
+      - Sat, 09 Jul 2016 22:49:25 GMT
+      Access-Control-Allow-Origin:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"code":404599104,"message":"Hmm, we can''t find this reservation.
+        Please double-check your information.","httpStatusCode":"NOT_FOUND","requestId":"AfxYUfq-SkCMgYXK4vqSGw-API"}'
+    http_version: 
+  recorded_at: Sat, 09 Jul 2016 22:49:25 GMT
+recorded_with: VCR 2.9.3

--- a/spec/jobs/checkin_job_spec.rb
+++ b/spec/jobs/checkin_job_spec.rb
@@ -105,4 +105,19 @@ RSpec.describe CheckinJob, :type => :job do
       end
     end
   end
+
+  context 'international flight' do
+    let(:reservation_cassette) { 'international 2016-07-08' }
+    let(:checkin_cassette) { 'international multi passenger 2016-07-09' }
+
+    include_context 'setup existing reservation'
+
+    it 'checks in' do
+      perform do
+        CheckinJob.perform_later(flight)
+        expect(flight.checkin.payload).to_not be_nil
+        expect(flight.checkin.completed_at).to_not be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/southwest/checkin_spec.rb
+++ b/spec/lib/southwest/checkin_spec.rb
@@ -16,8 +16,20 @@ RSpec.describe Southwest::Checkin do
   }
 
   describe '.checkin' do
-    it 'matches the JSON schema for boarding passes' do
+    it 'standard flight' do
       VCR.use_cassette cassette do
+        expect(subject.checkin.body).to match_json_schema(:record_locator_boarding_passes)
+      end
+    end
+
+    it 'international multi passenger' do
+      VCR.use_cassette 'international multi passenger 2016-07-09' do
+        expect(subject.checkin.body).to match_json_schema(:record_locator_boarding_passes)
+      end
+    end
+
+    it 'international single passenger' do
+      VCR.use_cassette 'international single passenger 2016-07-09' do
         expect(subject.checkin.body).to match_json_schema(:record_locator_boarding_passes)
       end
     end

--- a/spec/support/schemas/southwest/record_locator_boarding_passes.json
+++ b/spec/support/schemas/southwest/record_locator_boarding_passes.json
@@ -28,19 +28,19 @@
               },
               "secureFlightMiddleName": {
                 "id": "secureFlightMiddleName",
-                "type": "string"
+                "type": ["string", "null"]
               },
               "secureFlightSuffix": {
                 "id": "secureFlightSuffix",
-                "type": "string"
+                "type": ["string", "null"]
               },
               "loyaltyAccountNumber": {
                 "id": "loyaltyAccountNumber",
-                "type": "string"
+                "type": ["string", "null"]
               },
               "tier": {
                 "id": "tier",
-                "type": "string"
+                "type": ["string", "null"]
               },
               "birthDate": {
                 "id": "birthDate",
@@ -118,11 +118,11 @@
                 },
                 "gate": {
                   "id": "gate",
-                  "type": "null"
+                  "type": ["string", "null"]
                 },
                 "flightNumber": {
                   "id": "flightNumber",
-                  "type": "string"
+                  "type": ["string", "null"]
                 },
                 "hasPreCheck": {
                   "id": "hasPreCheck",
@@ -152,7 +152,7 @@
                 },
                 "drinkCouponBarCode": {
                   "id": "drinkCouponBarCode",
-                  "type": "null"
+                  "type": ["string", "null"]
                 },
                 "issued": {
                   "id": "issued",


### PR DESCRIPTION
- Fixes an issue where a flight number can come from a different API field
- Fixes `rake dev:prime`
- With international flights, warn the user that passport information is required

Closes #56 