### PR TITLE
Make confirmation numbers unique until they are completed

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -20,6 +20,8 @@ class Reservation < ActiveRecord::Base
             :payload,
             presence: true
 
+  validate :validate_unique_active_confirmation, on: :create
+
   scope :ordered_by_departure_time, -> { includes(:flights).order("flights.departure_time") }
 
   def departure_flights
@@ -95,5 +97,12 @@ class Reservation < ActiveRecord::Base
 
   def send_new_reservation_email
     ReservationMailer.new_reservation(self).deliver_later
+  end
+
+  def validate_unique_active_confirmation
+    any = Checkin.joins(:reservation).not_completed.where('reservations.confirmation_number' => confirmation_number).exists?
+    if any
+      errors.add(:confirmation_number, 'is already scheduled')
+    end
   end
 end


### PR DESCRIPTION
This prevents scheduling the same confirmation number more than once, until any associated checkins have been completed.

This will prevent someone accidentally clicking the "Add reservation" button multiple times, and scheduling the same flight many times.

I didn't add an uniqueness validation to the confirmation_number field since they are periodically re-used, see [Wiki page](https://en.wikipedia.org/wiki/Record_locator)